### PR TITLE
RC mode reading now stops controller, RTK position and velocity messages and battery state now have timestamps

### DIFF
--- a/dji_sdk/include/dji_sdk/dji_sdk_node.h
+++ b/dji_sdk/include/dji_sdk/dji_sdk_node.h
@@ -266,7 +266,7 @@ private:
 
 private:
   //! If set to false, any Joy control message will be discarded
-  std::atomic<bool> can_control = false;
+  std::atomic<bool> can_control;
 
   //! OSDK core
   Vehicle* vehicle;

--- a/dji_sdk/include/dji_sdk/dji_sdk_node.h
+++ b/dji_sdk/include/dji_sdk/dji_sdk_node.h
@@ -12,6 +12,8 @@
 #ifndef DJI_SDK_NODE_MAIN_H
 #define DJI_SDK_NODE_MAIN_H
 
+#include <atomic>
+
 //! ROS
 #include <ros/ros.h>
 #include <tf/tf.h>
@@ -263,6 +265,9 @@ private:
 #endif
 
 private:
+  //! If set to false, any Joy control message will be discarded
+  std::atomic<bool> can_control = false;
+
   //! OSDK core
   Vehicle* vehicle;
   //! general service servers

--- a/dji_sdk/src/modules/dji_sdk_node.cpp
+++ b/dji_sdk/src/modules/dji_sdk_node.cpp
@@ -17,7 +17,8 @@ DJISDKNode::DJISDKNode(ros::NodeHandle& nh, ros::NodeHandle& nh_private)
   : telemetry_from_fc(USE_BROADCAST),
     R_FLU2FRD(tf::Matrix3x3(1,  0,  0, 0, -1,  0, 0,  0, -1)),
     R_ENU2NED(tf::Matrix3x3(0,  1,  0, 1,  0,  0, 0,  0, -1)),
-    curr_align_state(UNALIGNED)
+    curr_align_state(UNALIGNED),
+    can_control(false)
 {
   nh_private.param("serial_name",   serial_device, std::string("/dev/ttyUSB0"));
   nh_private.param("baud_rate",     baud_rate, 921600);

--- a/dji_sdk/src/modules/dji_sdk_node.cpp
+++ b/dji_sdk/src/modules/dji_sdk_node.cpp
@@ -182,7 +182,7 @@ bool
 DJISDKNode::initFlightControl(ros::NodeHandle& nh)
 {
   flight_control_sub = nh.subscribe<sensor_msgs::Joy>(
-    "dji_sdk/flight_control_setpoint_generic", 10, 
+    "dji_sdk/flight_control_setpoint_generic", 10,
     &DJISDKNode::flightControlSetpointCallback,   this);
 
   flight_control_position_yaw_sub =
@@ -300,7 +300,7 @@ DJISDKNode::initPublisher(ros::NodeHandle& nh)
       nh.advertise<sensor_msgs::NavSatFix>("dji_sdk/rtk_position", 10);
 
   rtk_velocity_publisher =
-      nh.advertise<geometry_msgs::Vector3>("dji_sdk/rtk_velocity", 10);
+      nh.advertise<geometry_msgs::Vector3Stamped>("dji_sdk/rtk_velocity", 10);
 
   rtk_yaw_publisher =
       nh.advertise<std_msgs::Int16>("dji_sdk/rtk_yaw", 10);

--- a/dji_sdk/src/modules/dji_sdk_node_control.cpp
+++ b/dji_sdk/src/modules/dji_sdk_node_control.cpp
@@ -29,6 +29,12 @@
  */
 void DJISDKNode::flightControl(uint8_t flag, float xSP, float ySP, float zSP, float yawSP)
 {
+  if(can_control == false)
+  {
+    ROS_WARN_THROTTLE(1, "Received Joy ctrl msg but can_control is set to False! Discarding...");
+    return;
+  }
+
   uint8_t HORI  = (flag & 0xC0);
   uint8_t VERT  = (flag & 0x30);
   uint8_t YAW   = (flag & 0x08);
@@ -118,7 +124,7 @@ void DJISDKNode::flightControl(uint8_t flag, float xSP, float ySP, float zSP, fl
 void
 DJISDKNode::flightControlSetpointCallback(
   const sensor_msgs::Joy::ConstPtr& pMsg)
-{ 
+{
   float xSP    = pMsg->axes[0];
   float ySP    = pMsg->axes[1];
   float zSP    = pMsg->axes[2];
@@ -180,4 +186,3 @@ DJISDKNode::flightControlRollPitchPzYawrateCallback(
 
   flightControl(flag, roll, pitch, pz, yawRate);
 }
-

--- a/dji_sdk/src/modules/dji_sdk_node_publisher.cpp
+++ b/dji_sdk/src/modules/dji_sdk_node_publisher.cpp
@@ -468,19 +468,19 @@ DJISDKNode::publish50HzData(Vehicle* vehicle, RecvContainer recvFrame,
     int16_t mode = vehicle->broadcast->getRC().mode;
 
     /* If mode is in P (10000) than can control the UAV*/
-    if (can_control == false && mode == 10000)
+    if (p->can_control == false && mode == 10000)
     {
       ROS_WARN_STREAM("can_control was False, but mode is now P(10000) " <<
                       "so activiating control, can_control = true, " <<
                       "you still need to manual request control authority!");
-      can_control = true;
+      p->can_control = true;
     }
     /* If mode is in F (-10000) than cannot control the UAV*/
-    else if (can_control == true && mode == -10000)
+    else if (p->can_control == true && mode == -10000)
     {
-      ROS_WARN("can_control was True, but mode is now F(-10000) so " <<
+      ROS_WARN_STREAM("can_control was True, but mode is now F(-10000) so " <<
                "DEACTIVATING control, can_control = false");
-      can_control = false;
+      p->can_control = false;
     }
 
     sensor_msgs::Joy rc_joy;

--- a/dji_sdk/src/modules/dji_sdk_node_publisher.cpp
+++ b/dji_sdk/src/modules/dji_sdk_node_publisher.cpp
@@ -190,14 +190,14 @@ DJISDKNode::dataBroadcastCallback()
     flight_status_publisher.publish(flight_status);
   }
 
-  uint16_t flag_has_gimbal = 
+  uint16_t flag_has_gimbal =
           isM100() ? (data_enable_flag & DataBroadcast::DATA_ENABLE_FLAG::HAS_GIMBAL) :
           (data_enable_flag & DataBroadcast::DATA_ENABLE_FLAG::A3_HAS_GIMBAL);
   if (flag_has_gimbal)
   {
     Telemetry::Gimbal gimbal_reading;
 
-    
+
     Telemetry::Gimbal gimbal_angle = vehicle->broadcast->getGimbal();
 
     geometry_msgs::Vector3Stamped gimbal_angle_vec3;
@@ -241,6 +241,9 @@ DJISDKNode::publish10HzData(Vehicle *vehicle, RecvContainer recvFrame,
   Telemetry::TypeMap<Telemetry::TOPIC_BATTERY_INFO>::type battery_info=
     vehicle->subscribe->getValue<Telemetry::TOPIC_BATTERY_INFO>();
   sensor_msgs::BatteryState msg_battery_state;
+
+  msg_battery_state.header.stamp = msg_time;
+
   msg_battery_state.capacity = NAN;
   msg_battery_state.voltage  = NAN;
   msg_battery_state.current  = NAN;
@@ -267,6 +270,9 @@ DJISDKNode::publish10HzData(Vehicle *vehicle, RecvContainer recvFrame,
         vehicle->subscribe->getValue<Telemetry::TOPIC_RTK_POSITION_INFO>();
 
     sensor_msgs::NavSatFix rtk_position;
+    rtk_position.header.stamp = msg_time;
+    rtk_position.header.frame_id = "rtk_WGS84";
+
     rtk_position.latitude = rtk_telemetry_position.latitude;
     rtk_position.longitude = rtk_telemetry_position.longitude;
     rtk_position.altitude = rtk_telemetry_position.HFSL;
@@ -274,10 +280,13 @@ DJISDKNode::publish10HzData(Vehicle *vehicle, RecvContainer recvFrame,
 
     //! Velocity converted to m/s to conform to REP103.
 
-    geometry_msgs::Vector3 rtk_velocity;
-    rtk_velocity.x = (rtk_telemetry_velocity.x)/100;
-    rtk_velocity.y = (rtk_telemetry_velocity.y)/100;
-    rtk_velocity.z = (rtk_telemetry_velocity.z)/100;
+    geometry_msgs::Vector3Stamped rtk_velocity;
+    rtk_velocity.header.stamp = msg_time;
+    rtk_velocity.header.frame_id = "rtk_NED";
+
+    rtk_velocity.vector.x = (rtk_telemetry_velocity.x)/100;
+    rtk_velocity.vector.y = (rtk_telemetry_velocity.y)/100;
+    rtk_velocity.vector.z = (rtk_telemetry_velocity.z)/100;
     p->rtk_velocity_publisher.publish(rtk_velocity);
 
     std_msgs::Int16 rtk_yaw;


### PR DESCRIPTION
- RC mode reading now stops controller
  - `atomic<bool> can_control` guards subscriber callbacks responsible for receiving Joy messages, when RC mode is switched into **P** then control is passed, when switched into **F** then control is *STOPPED*
- RTK position and velocity messages and battery state messages now have timestamps